### PR TITLE
TypeError in convert_to_gtdb Process

### DIFF
--- a/recipes/agora2/agora2.nf
+++ b/recipes/agora2/agora2.nf
@@ -77,7 +77,7 @@ process convert_to_gtdb {
     rank_idx = gtdb_rank_names.get_loc("${level}")
     tax = meta.gtdb_taxonomy.str.split(";", expand=True)
     tax.columns = gtdb_rank_names
-    meta = pd.concat([meta, tax], 1).drop(["gtdb_taxonomy"], axis=1).drop_duplicates()
+    meta = pd.concat([meta, tax], axis = 1).drop(["gtdb_taxonomy"], axis=1).drop_duplicates()
 
     agora = pd.read_csv("${manifest}", sep="\\t").drop(
         ["strain", "species", "genus" , "family","order", "class", "phylum", "kingdom"],


### PR DESCRIPTION
The Nextflow pipeline agora2.nf fails during the execution of the convert_to_gtdb process due to a TypeError in the Python script. The error occurs when attempting to concatenate DataFrames using pd.concat.

```
Traceback (most recent call last):
  File ".command.sh", line 16, in <module>
    meta = pd.concat([meta, tax], 1).drop(["gtdb_taxonomy"], axis=1).drop_duplicates()
TypeError: concat() takes 1 positional argument but 2 were given
```

I modified the script slightly to pass the axis parameter directly to pd.concat and this seems to have worked:

`meta = pd.concat([meta, tax], axis=1).drop(["gtdb_taxonomy"], axis=1).drop_duplicates()`

